### PR TITLE
Added invert method to ordinal scale

### DIFF
--- a/src/NumericInterpolator/NSOrdinalScale.class.st
+++ b/src/NumericInterpolator/NSOrdinalScale.class.st
@@ -8,7 +8,8 @@ Class {
 		'ranger',
 		'dictionary',
 		'argument',
-		'rangeBand'
+		'rangeBand',
+		'linearScale'
 	],
 	#category : #'NumericInterpolator-Scales'
 }
@@ -20,13 +21,16 @@ NSOrdinalScale >> dictionary [
 
 { #category : #accessing }
 NSOrdinalScale >> domain: arr [
+
 	domain := OrderedCollection new.
 	dictionary := Dictionary new.
 	arr do: [ :xi |
 		dictionary at: xi ifAbsentPut: [
 			domain add: xi.
 			domain size ] ].
-	self perform: ranger withArguments: argument
+	self perform: ranger withArguments: argument.
+
+	self rescale
 ]
 
 { #category : #initialization }
@@ -40,22 +44,18 @@ NSOrdinalScale >> initialize [
 { #category : #transformation }
 NSOrdinalScale >> invert: anObject [
 
-	^ NSScale linear
-		  domain: {
-				  domain first.
-				  domain last };
-		  range: {
-				  range first.
-				  range last };
-		  invert: anObject
+	^ linearScale invert: anObject
 ]
 
 { #category : #accessing }
 NSOrdinalScale >> range: x [
+
 	range := x.
 	rangeBand := 0.
 	ranger := #range:.
-	argument := Array with: x
+	argument := Array with: x.
+
+	self rescale
 ]
 
 { #category : #accessing }
@@ -181,18 +181,23 @@ NSOrdinalScale >> rangeRoundPoints: x padding: padding [
 	argument := Array with: x with: padding
 ]
 
+{ #category : #hooks }
+NSOrdinalScale >> rescale [
+
+	linearScale := NSScale linear
+		domain: { domain first. domain last };
+		range: { range first.  range last };
+		yourself
+]
+
 { #category : #transformation }
 NSOrdinalScale >> scale: x [
 	| index |
 	index := dictionary at: x ifAbsent: [ nil ].
 	(index isNil and: [ ranger = #range:]) ifTrue: [
 		domain add: x.
-		dictionary at: x put: (index := domain size).
-		].
-	index ifNil: [ ^ NSScale linear
-		domain: {domain first. domain last};
-		range: {range first. range last};
-		scale: x ].
+		dictionary at: x put: (index := domain size) ].
+	index ifNil: [ ^ linearScale scale: x ].
 
 	index := index % range size.
 	index isZero

--- a/src/NumericInterpolator/NSOrdinalScale.class.st
+++ b/src/NumericInterpolator/NSOrdinalScale.class.st
@@ -8,8 +8,7 @@ Class {
 		'ranger',
 		'dictionary',
 		'argument',
-		'rangeBand',
-		'linearScale'
+		'rangeBand'
 	],
 	#category : #'NumericInterpolator-Scales'
 }
@@ -28,9 +27,7 @@ NSOrdinalScale >> domain: arr [
 		dictionary at: xi ifAbsentPut: [
 			domain add: xi.
 			domain size ] ].
-	self perform: ranger withArguments: argument.
-
-	self rescale
+	self perform: ranger withArguments: argument
 ]
 
 { #category : #initialization }
@@ -44,7 +41,16 @@ NSOrdinalScale >> initialize [
 { #category : #transformation }
 NSOrdinalScale >> invert: anObject [
 
-	^ linearScale invert: anObject
+	^ self linearScale invert: anObject
+]
+
+{ #category : #transformation }
+NSOrdinalScale >> linearScale [
+
+	^ NSScale linear
+		domain: { domain first. domain last };
+		range: { range first.  range last };
+		yourself
 ]
 
 { #category : #accessing }
@@ -53,9 +59,7 @@ NSOrdinalScale >> range: x [
 	range := x.
 	rangeBand := 0.
 	ranger := #range:.
-	argument := Array with: x.
-
-	self rescale
+	argument := Array with: x
 ]
 
 { #category : #accessing }
@@ -181,15 +185,6 @@ NSOrdinalScale >> rangeRoundPoints: x padding: padding [
 	argument := Array with: x with: padding
 ]
 
-{ #category : #hooks }
-NSOrdinalScale >> rescale [
-
-	linearScale := NSScale linear
-		domain: { domain first. domain last };
-		range: { range first.  range last };
-		yourself
-]
-
 { #category : #transformation }
 NSOrdinalScale >> scale: x [
 	| index |
@@ -197,7 +192,7 @@ NSOrdinalScale >> scale: x [
 	(index isNil and: [ ranger = #range:]) ifTrue: [
 		domain add: x.
 		dictionary at: x put: (index := domain size) ].
-	index ifNil: [ ^ linearScale scale: x ].
+	index ifNil: [ ^ self linearScale scale: x ].
 
 	index := index % range size.
 	index isZero

--- a/src/NumericInterpolator/NSOrdinalScale.class.st
+++ b/src/NumericInterpolator/NSOrdinalScale.class.st
@@ -39,7 +39,15 @@ NSOrdinalScale >> initialize [
 
 { #category : #transformation }
 NSOrdinalScale >> invert: anObject [
-	self shouldNotImplement
+
+	^ NSScale linear
+		  domain: {
+				  domain first.
+				  domain last };
+		  range: {
+				  range first.
+				  range last };
+		  invert: anObject
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
If we see the implementation of the NSOrdinalScale, we see that the scale method `NSOrdinalScale>>#scale:` creates a linear scale to scale the numbers. See:

```st
^ NSScale linear
		domain: {domain first. domain last};
		range: {range first. range last};
		scale: x
```

So it is scaling with a linear scale. This PR add the equivalent invert: method that inverts using the same linear scale. Maybe it is not the best solution but it is consistent with the current implementation.