### PR TITLE
Move the nice ticks algorithm to this repo. Added testsSeveral refactors

### DIFF
--- a/src/NumericInterpolator-Tests/NSLogScaleTest.class.st
+++ b/src/NumericInterpolator-Tests/NSLogScaleTest.class.st
@@ -11,7 +11,7 @@ Class {
 NSLogScaleTest >> testLogScale [
 	| log |
 	log := NSLogScale new.
-	self
+	self 
 		assert: log base equals: 10;
 		assert: log range equals: #(0 1);
 		assert: (log scale: 10) equals: 1;
@@ -25,13 +25,41 @@ NSLogScaleTest >> testLogScale [
 	self assert: ((log scale: 0.01) closeTo: 302.3371152441798).
 	self assert: ((log scale: 100) closeTo: 97.66288475582019).
 	self assert: ((log invert: 10) closeTo: 5166.754427175983).
-
+	
 	self assert: (log scale: 9000) closeTo: -2.3328856959635047.
 	log clamp: true.
 	self
 		assert: (log scale: 9000) closeTo: 0;
 		assert: log interpolate equals: NSInterpolator.
 	log interpolate: NSInterpolator
+	
+
+]
+
+{ #category : #'test - scales' }
+NSLogScaleTest >> testMultiLogScaleInvert [
+
+	| log |
+	log := NSLogScale new
+		       base: Float e;
+		       domain: (#( 0 5 9 ) collect: #exp);
+		       range: #( 300 80 0 ).
+	self assert: ((log invert: 300) closeTo: 0 exp).
+	self assert: ((log invert: 80) closeTo: 5 exp).
+	self assert: ((log invert: 0) closeTo: 9 exp)
+]
+
+{ #category : #'test - scales' }
+NSLogScaleTest >> testMultiLogScaleScale [
+
+	| log |
+	log := NSLogScale new
+		       base: Float e;
+		       domain: (#( 0 5 9 ) collect: #exp);
+		       range: #( 300 80 0 ).
+	self assert: ((log scale: 0 exp) closeTo: 300).
+	self assert: ((log scale: 5 exp) closeTo: 80).
+	self assert: ((log scale: 9 exp) closeTo: 0)
 ]
 
 { #category : #'test - scales' }

--- a/src/NumericInterpolator-Tests/NSNiceLinearTicksGeneratorTest.class.st
+++ b/src/NumericInterpolator-Tests/NSNiceLinearTicksGeneratorTest.class.st
@@ -1,5 +1,5 @@
 Class {
-	#name : #RSLabelGeneratorTest,
+	#name : #NSNiceLinearTicksGeneratorTest,
 	#superclass : #TestCase,
 	#instVars : [
 		'lg'
@@ -8,7 +8,7 @@ Class {
 }
 
 { #category : #running }
-RSLabelGeneratorTest >> setUp [
+NSNiceLinearTicksGeneratorTest >> setUp [
 	| nice |
 	super setUp.
 	nice := NSNiceLinearScaleStepSizeGenerator new.
@@ -16,7 +16,7 @@ RSLabelGeneratorTest >> setUp [
 ]
 
 { #category : #tests }
-RSLabelGeneratorTest >> testError [
+NSNiceLinearTicksGeneratorTest >> testError [
 	self
 		should: [ lg searchMin: -98.0 max: 18.0 desired: 1 ]
 		raise: Error
@@ -28,7 +28,7 @@ RSLabelGeneratorTest >> testError [
 ]
 
 { #category : #tests }
-RSLabelGeneratorTest >> testSearch [
+NSNiceLinearTicksGeneratorTest >> testSearch [
 	| label |
 	lg setLooseFlag: true.
 	label := lg searchMin: -98.0 max: 18.0 desired: 3.

--- a/src/NumericInterpolator-Tests/NSSymLogScaleTest.class.st
+++ b/src/NumericInterpolator-Tests/NSSymLogScaleTest.class.st
@@ -17,6 +17,20 @@ NSSymLogScaleTest >> testBasic [
 ]
 
 { #category : #tests }
+NSSymLogScaleTest >> testInvert [
+
+	| scale domain range |
+	domain := { -5.0 . 500.0 }.
+	range := { 0. 1 }.
+	scale := NSSymLogScale new
+		domain: domain;
+		range: range;
+		yourself.
+	self assert: scale domain first closeTo: (scale invert: scale range first).
+	self assert: scale domain second closeTo: (scale invert: scale range second)
+]
+
+{ #category : #tests }
 NSSymLogScaleTest >> testTicks [
 
 	| expectedTicks scale |

--- a/src/NumericInterpolator-Tests/RSLabelGeneratorTest.class.st
+++ b/src/NumericInterpolator-Tests/RSLabelGeneratorTest.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : #RSLabelGeneratorTest,
-	#superclass : #RSTest,
+	#superclass : #TestCase,
 	#instVars : [
 		'lg'
 	],

--- a/src/NumericInterpolator-Tests/RSLabelGeneratorTest.class.st
+++ b/src/NumericInterpolator-Tests/RSLabelGeneratorTest.class.st
@@ -1,0 +1,131 @@
+Class {
+	#name : #RSLabelGeneratorTest,
+	#superclass : #RSTest,
+	#instVars : [
+		'lg'
+	],
+	#category : #'NumericInterpolator-Tests'
+}
+
+{ #category : #running }
+RSLabelGeneratorTest >> setUp [
+	| nice |
+	super setUp.
+	nice := NSNiceLinearScaleStepSizeGenerator new.
+	lg := NSNiceLinearTicksGenerator nice: nice
+]
+
+{ #category : #tests }
+RSLabelGeneratorTest >> testError [
+	self
+		should: [ lg searchMin: -98.0 max: 18.0 desired: 1 ]
+		raise: Error
+		description: 'entry to short'.
+	self
+		should: [ lg searchMin: -98.0 max: 18.0 desired: 0 ]
+		raise: Error
+		description: 'entry to short'
+]
+
+{ #category : #tests }
+RSLabelGeneratorTest >> testSearch [
+	| label |
+	lg setLooseFlag: true.
+	label := lg searchMin: -98.0 max: 18.0 desired: 3.
+	self
+		assert: label asString
+		equals: '(Score: 0.14) -100.00	-60.00	-20.00	20.00	'.
+	lg setLooseFlag: false.
+	label := lg searchMin: -98.0 max: 18.0 desired: 3.
+	self
+		assert: label asString
+		equals: '(Score: 0.62) -100.00	-50.00	0.00	'.
+	lg setLooseFlag: true.
+	label := lg searchMin: -1 max: 3.5 desired: 4.
+	self
+		assert: label asString
+		equals: '(Score: 0.54) -1.00	0.00	1.00	2.00	3.00	4.00	'.
+	lg setLooseFlag: false.
+	label := lg searchMin: -1 max: 3.5 desired: 4.
+	self
+		assert: label asString
+		equals: '(Score: 0.63) -1.00	0.00	1.00	2.00	3.00	'.
+	lg setLooseFlag: true.
+	label := lg searchMin: -1 max: 200 desired: 3.
+	self
+		assert: label asString
+		equals: '(Score: -0.29) -25.00	50.00	125.00	200.00	'.
+	lg setLooseFlag: false.
+	label := lg searchMin: -1 max: 200 desired: 3.
+	self
+		assert: label asString
+		equals: '(Score: 1.00) 0.00	100.00	200.00	'.
+	lg setLooseFlag: true.
+	label := lg searchMin: 119 max: 178 desired: 3.
+	self
+		assert:
+			(label asString = '(Score: -0.65) 110.00	150.00	190.00	'
+				or: [ label asString
+						= '(Score: -0.65) 110.00	130.00	150.00	170.00	190.00	' ]).
+	lg setLooseFlag: false.
+	label := lg searchMin: 119 max: 178 desired: 3.
+	self
+		assert: label asString
+		equals: '(Score: 0.48) 120.00	150.00	180.00	'.
+	lg setLooseFlag: true.
+	label := lg searchMin: -31 max: 27 desired: 4.
+	self
+		assert: label asString
+		equals: '(Score: 0.07) -40.00	-30.00	-20.00	-10.00	0.00	10.00	20.00	30.00	'.
+	lg setLooseFlag: false.
+	label := lg searchMin: -31 max: 27 desired: 3.
+	self
+		assert: label asString
+		equals: '(Score: 0.71) -30.00	0.00	30.00	'.
+	lg setLooseFlag: true.
+	label := lg searchMin: -55.45 max: -49.99 desired: 2.
+	self assert: label asString equals: '(Score: -1.13) -56.00	-48.00	'.
+	lg setLooseFlag: false.
+	label := lg searchMin: -55.45 max: -49.99 desired: 3.
+	self
+		assert: label asString
+		equals: '(Score: 0.49) -55.00	-52.50	-50.00	'.
+	lg setLooseFlag: false.
+	label := lg searchMin: 0 max: 100 desired: 2.
+	self assert: label asString equals: '(Score: 1.00) 0.00	100.00	'.
+	label := lg searchMin: 0 max: 100 desired: 3.
+	self
+		assert: label asString
+		equals: '(Score: 0.95) 0.00	50.00	100.00	'.
+	label := lg searchMin: 0 max: 100 desired: 4.
+	self
+		assert: label asString
+		equals: '(Score: 0.70) 0.00	50.00	100.00	'.
+	label := lg searchMin: 0 max: 100 desired: 5.
+	self
+		assert: label asString
+		equals: '(Score: 0.85) 0.00	25.00	50.00	75.00	100.00	'.
+	label := lg searchMin: 0 max: 100 desired: 6.
+	self
+		assert: label asString
+		equals: '(Score: 0.90) 0.00	20.00	40.00	60.00	80.00	100.00	'.
+	label := lg searchMin: 0 max: 100 desired: 7.
+	self
+		assert: label asString
+		equals: '(Score: 0.80) 0.00	20.00	40.00	60.00	80.00	100.00	'.
+	label := lg searchMin: 0 max: 100 desired: 8.
+	self
+		assert: label asString
+		equals:
+			'(Score: 0.79) 0.00	10.00	20.00	30.00	40.00	50.00	60.00	70.00	80.00	90.00	100.00	'.
+	label := lg searchMin: 0 max: 100 desired: 9.
+	self
+		assert: label asString
+		equals:
+			'(Score: 0.88) 0.00	10.00	20.00	30.00	40.00	50.00	60.00	70.00	80.00	90.00	100.00	'.
+	label := lg searchMin: 0 max: 100 desired: 10.
+	self
+		assert: label asString
+		equals:
+			'(Score: 0.94) 0.00	10.00	20.00	30.00	40.00	50.00	60.00	70.00	80.00	90.00	100.00	'
+]

--- a/src/NumericInterpolator/NSLinearScale.class.st
+++ b/src/NumericInterpolator/NSLinearScale.class.st
@@ -59,6 +59,9 @@ NSLinearScale >> invert: y [
 NSLinearScale >> niceTicks: numberOfTicks [
 
 	| generator niceLabel |
+	domain min = domain max ifTrue: [ ^ self ticks: numberOfTicks ].
+	numberOfTicks < 2 ifTrue: [ ^ self ticks: numberOfTicks ].
+
 	generator := NSNiceLinearTicksGenerator new setLooseFlag: true.
 	niceLabel := generator searchMin: domain min max: domain max desired: numberOfTicks.
 
@@ -104,13 +107,4 @@ NSLinearScale >> rescale [
 { #category : #transformation }
 NSLinearScale >> scale: x [
 	^ output scale: x
-]
-
-{ #category : #transformation }
-NSLinearScale >> ticks: anInteger [
-
-	| rangeForDividing |
-	rangeForDividing := range first to: range last count: anInteger.
-
-	^ rangeForDividing collect: [ :e | self invert: e ]
 ]

--- a/src/NumericInterpolator/NSLinearScale.class.st
+++ b/src/NumericInterpolator/NSLinearScale.class.st
@@ -56,6 +56,16 @@ NSLinearScale >> invert: y [
 ]
 
 { #category : #accessing }
+NSLinearScale >> niceTicks: numberOfTicks [
+
+	| generator niceLabel |
+	generator := NSNiceLinearTicksGenerator new setLooseFlag: true.
+	niceLabel := generator searchMin: domain min max: domain max desired: numberOfTicks.
+
+	^ niceLabel min to: niceLabel max by: niceLabel step
+]
+
+{ #category : #accessing }
 NSLinearScale >> output [
 	^ output
 ]

--- a/src/NumericInterpolator/NSLnScale.class.st
+++ b/src/NumericInterpolator/NSLnScale.class.st
@@ -50,12 +50,6 @@ NSLnScale >> invert: x [
 ]
 
 { #category : #accessing }
-NSLnScale >> niceTicks: aNumberOfTicks [
-
-	^ self ticks: aNumberOfTicks
-]
-
-{ #category : #accessing }
 NSLnScale >> range [
 	^ linear range
 ]

--- a/src/NumericInterpolator/NSLnScale.class.st
+++ b/src/NumericInterpolator/NSLnScale.class.st
@@ -3,7 +3,7 @@ I use natural logarithms to compute scales.
 "
 Class {
 	#name : #NSLnScale,
-	#superclass : #NSLinearScale,
+	#superclass : #NSScale,
 	#instVars : [
 		'linear'
 	],
@@ -62,6 +62,8 @@ NSLnScale >> range [
 
 { #category : #accessing }
 NSLnScale >> range: x [
+
+	range := x.
 	linear range: x
 ]
 

--- a/src/NumericInterpolator/NSLnScale.class.st
+++ b/src/NumericInterpolator/NSLnScale.class.st
@@ -50,6 +50,12 @@ NSLnScale >> invert: x [
 ]
 
 { #category : #accessing }
+NSLnScale >> niceTicks: aNumberOfTicks [
+
+	^ self ticks: aNumberOfTicks
+]
+
+{ #category : #accessing }
 NSLnScale >> range [
 	^ linear range
 ]

--- a/src/NumericInterpolator/NSLogScale.class.st
+++ b/src/NumericInterpolator/NSLogScale.class.st
@@ -11,7 +11,7 @@ log scale: 0
 "
 Class {
 	#name : #NSLogScale,
-	#superclass : #NSLinearScale,
+	#superclass : #NSScale,
 	#instVars : [
 		'linear',
 		'base',
@@ -103,6 +103,8 @@ NSLogScale >> range [
 
 { #category : #accessing }
 NSLogScale >> range: x [
+
+	range := x.
 	linear range: x
 ]
 

--- a/src/NumericInterpolator/NSLogScale.class.st
+++ b/src/NumericInterpolator/NSLogScale.class.st
@@ -83,12 +83,6 @@ NSLogScale >> lg: x [
 		/ (base ln)
 ]
 
-{ #category : #accessing }
-NSLogScale >> niceTicks: aNumberOfTicks [
-
-	^ self ticks: aNumberOfTicks
-]
-
 { #category : #'math functions' }
 NSLogScale >> pow: x [
 	^ positive

--- a/src/NumericInterpolator/NSLogScale.class.st
+++ b/src/NumericInterpolator/NSLogScale.class.st
@@ -83,6 +83,12 @@ NSLogScale >> lg: x [
 		/ (base ln)
 ]
 
+{ #category : #accessing }
+NSLogScale >> niceTicks: aNumberOfTicks [
+
+	^ self ticks: aNumberOfTicks
+]
+
 { #category : #'math functions' }
 NSLogScale >> pow: x [
 	^ positive

--- a/src/NumericInterpolator/NSNiceLinearScaleStep.class.st
+++ b/src/NumericInterpolator/NSNiceLinearScaleStep.class.st
@@ -1,0 +1,55 @@
+"
+I am an utility class for RTNiceStepSizeGenerator>>next
+
+"
+Class {
+	#name : #NSNiceLinearScaleStep,
+	#superclass : #RSObject,
+	#instVars : [
+		'stepSize',
+		'offset',
+		'i',
+		'j'
+	],
+	#category : #'NumericInterpolator-Nice Scaling'
+}
+
+{ #category : #accessing }
+NSNiceLinearScaleStep >> i [
+	^ i
+]
+
+{ #category : #accessing }
+NSNiceLinearScaleStep >> i: aNumber [
+	i := aNumber
+]
+
+{ #category : #accessing }
+NSNiceLinearScaleStep >> j [
+	^ j
+]
+
+{ #category : #accessing }
+NSNiceLinearScaleStep >> j: aNumber [
+	j := aNumber
+]
+
+{ #category : #accessing }
+NSNiceLinearScaleStep >> offset [
+	^ offset
+]
+
+{ #category : #accessing }
+NSNiceLinearScaleStep >> offset: aNumber [
+	offset := aNumber
+]
+
+{ #category : #accessing }
+NSNiceLinearScaleStep >> stepSize [
+	^ stepSize
+]
+
+{ #category : #accessing }
+NSNiceLinearScaleStep >> stepSize: aNumber [
+	stepSize := aNumber
+]

--- a/src/NumericInterpolator/NSNiceLinearScaleStepSizeGenerator.class.st
+++ b/src/NumericInterpolator/NSNiceLinearScaleStepSizeGenerator.class.st
@@ -1,0 +1,155 @@
+"
+Nice numbers are just step sizes and used for tick spacing. We will use only niceStep tick
+ spaces and place tick marks at multiples of tick spacing.
+  
+  References:
+  	[1] An Extension of Wilkinson's Algorithm for positioning Tick Labels on Axes
+  		 				(Justin Talbot, Sharon Lin, Pat Hanrahan)
+   [2] Nice Numbers for Graph Labels (Paul S. Heckbert, Graphic Gems I)
+
+Here is an example on how to use it:
+-=-=-=-=-=-=-=-=-=
+nice := RSNiceStepSizeGenerator new.
+lg := RSLabelGenerator nice: nice.
+
+lg setLooseFlag: true.
+label := lg searchMin: -98.0 max: 18.0 desired: 3.
+label asString
+-=-=-=-=-=-=-=-=-=
+This prints  '(Score: 0.14) -100.00	-60.00	-20.00	20.00	'
+"
+Class {
+	#name : #NSNiceLinearScaleStepSizeGenerator,
+	#superclass : #RSObject,
+	#instVars : [
+		'qvar',
+		'i',
+		'io',
+		'j',
+		'q',
+		'ss',
+		'ovar',
+		'ssOffMap',
+		'resetRequired',
+		'base',
+		'niceStep',
+		'o'
+	],
+	#category : #'NumericInterpolator-Nice Scaling'
+}
+
+{ #category : #accessing }
+NSNiceLinearScaleStepSizeGenerator >> base [
+	^ base
+]
+
+{ #category : #initialization }
+NSNiceLinearScaleStepSizeGenerator >> initialize [
+	"Generates a NiceNumberGenerator"
+
+	super initialize.
+	niceStep := NSNiceLinearScaleStep new.
+	o := 0.0.
+	self setQ: #(1 5 2 2.5 4 3) base: 10
+]
+
+{ #category : #private }
+NSNiceLinearScaleStepSizeGenerator >> logB: a [
+	^ a ln / base ln
+]
+
+{ #category : #public }
+NSNiceLinearScaleStepSizeGenerator >> next [
+	| oSet |
+
+	niceStep
+		stepSize: ss;
+		offset: o;
+		i: i; "all output and calculations shouls add 1 because wilkinsons index start from 1"
+		j: j.
+	"Keep track of existing offsets and stepSizes to avoid duplicate returns of
+	step size, offset pairs"
+	(ssOffMap includesKey: ss) ifTrue: [
+		oSet := ssOffMap at: ss.
+		[ | b |
+			b := oSet includes: o.
+			oSet add: o.
+			b not and: [io < (ovar size - 1)] ] whileTrue: [
+			 io := io +1.
+			 niceStep offset: (o := ovar at: io +1 ). ].
+		 ] ifFalse: [
+		oSet := Set new.
+		oSet add: o.
+		ssOffMap at: ss put: oSet.
+		 ].
+	io := io +1."position for next offset if it exists"
+
+	"iterate for next call"
+	io < ovar size ifTrue: [ o := ovar at: io +1  ]
+	ifFalse: [
+		io := 0.
+		i := (i< (qvar size - 1) ) ifTrue: [ i+1 ] ifFalse: [ 0 ] .
+		j := i = 0 ifTrue: [ j+1 ] ifFalse: [ j ].
+		q := self qat: i.
+		ss := self stepSize: j q: q.
+		ovar := self offsets: j q: q.
+		o := ovar at: io + 1.
+	].
+	resetRequired := true.
+	^ niceStep
+]
+
+{ #category : #private }
+NSNiceLinearScaleStepSizeGenerator >> offsets: tj q: tq [
+	| offs |
+	offs := Array new: tj.
+	(0 to: tj-1) do: [ :ti |
+		offs at: ti+1 put: ((tq*ti) raisedTo: (self logB: tj*tq) ) ].
+	^ offs
+]
+
+{ #category : #private }
+NSNiceLinearScaleStepSizeGenerator >> qat: index [
+	^ qvar at: index + 1
+]
+
+{ #category : #accessing }
+NSNiceLinearScaleStepSizeGenerator >> qvar [
+	^ qvar
+]
+
+{ #category : #initialization }
+NSNiceLinearScaleStepSizeGenerator >> reset [
+	resetRequired ifFalse: [ ^ self ].
+	i := 0.
+	io := 0.
+	j := 1.
+	q := self qat: i.
+	ss := self stepSize: j q: q.
+	ssOffMap := Dictionary new.
+	resetRequired := false
+]
+
+{ #category : #initialization }
+NSNiceLinearScaleStepSizeGenerator >> setQ: anArray base: aNumber [
+	"anArray: preference ordered list of niceStep step sizes.
+	The deault is set by the initializer selector
+
+	aNumber: is a number of logs and exps usually changed together with Q"
+	qvar := anArray.
+	base := aNumber.
+	i := 0.
+	io := 0.
+	j := 1.
+	q := self qat: i.
+	ss := self stepSize: j q: q.
+	ovar := self offsets: j q: q.
+	ssOffMap := Dictionary new.
+	resetRequired := false
+]
+
+{ #category : #private }
+NSNiceLinearScaleStepSizeGenerator >> stepSize: tj q: tq [
+
+	^ tj * tq / (base raisedTo: (self logB: tj*tq ) floor )
+]

--- a/src/NumericInterpolator/NSNiceLinearTicksGenerator.class.st
+++ b/src/NumericInterpolator/NSNiceLinearTicksGenerator.class.st
@@ -1,0 +1,226 @@
+"
+Reference:
+ 	[1] An Extension of Wilkinson's Algorithm for positioning Tick Labels on Axes  (Justin Talbot, Sharon Lin, Pat Hanrahan)
+"
+Class {
+	#name : #NSNiceLinearTicksGenerator,
+	#superclass : #RSObject,
+	#instVars : [
+		'nice',
+		'loose',
+		'n',
+		'w',
+		'epsilon'
+	],
+	#category : #'NumericInterpolator-Nice Scaling'
+}
+
+{ #category : #'instance creation' }
+NSNiceLinearTicksGenerator class >> nice: aNiceGenerator [
+	^ self new nice: aNiceGenerator
+]
+
+{ #category : #private }
+NSNiceLinearTicksGenerator >> coverageMin: dmin max: dmax lmin: lmin lmax: lmax [
+	| a b c|
+	a := dmax - lmax.
+	b := dmin - lmin.
+	c := 0.1 * (dmax - dmin).
+	^ 1 - ( 0.5 * (((a * a) + (b * b))/ (c * c)) )
+]
+
+{ #category : #private }
+NSNiceLinearTicksGenerator >> coverageMin: dmin max: dmax span: span [
+	| range r half|
+	range := dmax - dmin.
+	(span > range) ifTrue: [
+		half := (span - range)/2.
+		r := 0.1*range.
+		^ 1 - (half * half / (r * r) )].
+	^ 1.0
+]
+
+{ #category : #private }
+NSNiceLinearTicksGenerator >> density: k m: m dmin: dmin dmax: dmax lmin: lmin lmax: lmax [
+	"* k		number of labels
+	 * m		number of desired labels
+	 * dmin	data range minimum
+	 * dmax	data range maximum
+	 * lmin	label range minimum
+	 * lmax	label range maximum
+	 * ^	density
+
+	 k-1 number of intervals between labels
+	 m-1 number of intervals between desired number of labels
+	 r   label interval length/label range
+	 rt  desired label interval length/actual range"
+	| r rt |
+	r := (k -1)/(lmax - lmin).
+	rt := (m - 1)/((lmax max: dmax) - (lmin min: dmin) ).
+	^ 2 - ( (r/rt) max: (rt/r) )
+]
+
+{ #category : #private }
+NSNiceLinearTicksGenerator >> densityMax: k m: m [
+	(k >= m) ifTrue: [ ^ 2 - ((k-1)/(m-1)) ].
+	^ 1
+]
+
+{ #category : #private }
+NSNiceLinearTicksGenerator >> epsilon [
+	" Compute the machine epsilon for the float type, the largest positive
+ 	floating-point value that, when added to 1, results in a value equal to 1 due to
+ 	roundoff."
+	| temp |
+	epsilon ifNotNil: [ ^ epsilon ].
+	temp := 0.5.
+	[ (1 + temp) > 1 ] whileTrue: [ temp := temp / 2 ].
+	epsilon := temp.
+	^ epsilon
+]
+
+{ #category : #private }
+NSNiceLinearTicksGenerator >> flooredMod: a n: num [
+	^ a - (num * (a / num) floor)
+]
+
+{ #category : #initialization }
+NSNiceLinearTicksGenerator >> initialize [
+	super initialize.
+	loose := false.
+	w := #(0.25 0.2 0.5 0.05).
+	self nice: NSNiceLinearScaleStepSizeGenerator new
+]
+
+{ #category : #private }
+NSNiceLinearTicksGenerator >> legibility: min max: max step: step [
+	^ 1
+]
+
+{ #category : #public }
+NSNiceLinearTicksGenerator >> nice: aNiceGenerator [
+	nice := aNiceGenerator
+]
+
+{ #category : #public }
+NSNiceLinearTicksGenerator >> searchMin: dmin max: dmax desired: desiredNumberOfTicks [
+	| best sm dm cm delta bestScore k |
+	best := RSNiceLinearScaleResult new.
+	bestScore := -2.
+	desiredNumberOfTicks <= 0 ifTrue: [ self error: 'The minimun value of desiredNumberOfTicks is 1' ].
+
+	"In case of a particular situation"
+	(dmin = 0 and: [ dmax = 0 ]) ifTrue: [
+		best
+			min: 0;
+			max: 1;
+			step: 1;
+			score: bestScore.
+		^ best ].
+
+	[ :break |
+		[ true ] whileTrue: [
+			n := nice next.
+			sm := self simplicityMax.
+			((self w: sm c: 1 d: 1 l: 1) < bestScore)
+				ifTrue: [ break value ].
+			k := 2.
+			[ :break2 |
+				[ true ] whileTrue: [ | z |
+					dm := [ self densityMax: k m: desiredNumberOfTicks ] on: ZeroDivide do: [ :ex | self error: 'Please increase the value of desiredNumberOfTicks/labels' ].
+					((self w: sm c: 1 d: dm l: 1) < bestScore)
+						ifTrue: [ break2 value ].
+					delta := (dmax - dmin)/(k+1)/ n j/ (nice qat: n i).
+					z := (nice logB: delta) ceiling.
+					[ :break3|
+						[ true ] whileTrue: [
+							[ :continue | | minStart maxStart step |
+								step := n j * (nice qat: n i) * (nice base raisedTo: z).
+								cm := self coverageMin: dmin max: dmax span: step * (k-1).
+								((self w: sm c: cm d: dm l: 1) < bestScore)
+									ifTrue: [ break3 value ].
+								minStart := ((dmax / step) floor - (k-1)) * n j.
+								maxStart := (dmin / step) ceiling * n j.
+								(minStart > maxStart) ifTrue: [
+									z := z +1.
+									continue value. ].
+
+								(minStart to: maxStart) do: [ :start |
+									| lmin lmax lstep c s d l score |
+									lmin := start * step / n j.
+									lmax := lmin + (step * (k -1)).
+									lstep := step.
+									c := self coverageMin: dmin max: dmax lmin: lmin lmax: lmax.
+									s := self simplicity: lmin max: lmax step: lstep.
+									d := self density: k m: desiredNumberOfTicks dmin: dmin dmax: dmax lmin: lmin lmax: lmax.
+									l := self legibility: lmin max: lmax step: lstep.
+									score := self w: s c: c d: d l: l.
+
+									((score > bestScore) and:
+									[ loose not or: [ (lmin <= dmin) and:
+														  [ lmax >= dmax ] ] ]) ifTrue: [
+										best
+											min: lmin;
+											max: lmax;
+											step: lstep;
+											score: score.
+											bestScore := score.
+									 ].
+								].
+								z := z +1.
+							] valueWithExit.
+						].
+					] valueWithExit.
+					k := k +1.
+				].
+			] valueWithExit.
+		 ]
+	] valueWithExit.
+
+	nice reset.
+
+	^ best
+]
+
+{ #category : #public }
+NSNiceLinearTicksGenerator >> setLooseFlag: aBool [
+	"Configuration to 'loose' labelings.
+	The extreme labels can be placement both inside(setLooseFlag: false) and outside (setLooseFlag: true) of the range of the data.
+
+	Example
+	.=.=.=.=.=.=.=.=.=.=.=.=.=.=.=.=.=
+	lg setLooseFlag: true.
+	label := lg searchMin: -98.0 max: 18.0 desired: 3.
+	self assert: label asString = '(Score: 0.14) -100.00	-60.00	-20.00	20.00	'.
+	lg setLooseFlag: false.
+	label := lg searchMin: -98.0 max: 18.0 desired: 3.
+	self assert: label asString = '(Score: 0.62) -100.00	-50.00	0.00	'.
+	.=.=.=.=.=.=.=.=.=.=.=.=.=.=.=.=.=
+	"
+	loose := aBool.
+	nice reset
+]
+
+{ #category : #private }
+NSNiceLinearTicksGenerator >> simplicity: min max: max step: step [
+	(nice qvar size > 1) ifTrue: [
+		^ 1 - (n i/ (nice qvar size - 1)) - n j + (self vMin: min max: max step: step) ].
+	^ 1 - n j + (self vMin: min max: max step: step)
+]
+
+{ #category : #private }
+NSNiceLinearTicksGenerator >> simplicityMax [
+	(nice qvar size > 1) ifTrue: [ ^ 1 - ((n i )/(nice qvar size -1)) - n j + 1.0 ].
+	 ^ 1 - n j + 1.0
+]
+
+{ #category : #private }
+NSNiceLinearTicksGenerator >> vMin: min max: max step: step [
+	^ ((self flooredMod: min n: step) < (self epsilon)
+	and: [ min <= 0 and: [ max >= 0 ] ]) ifTrue: [ 1 ] ifFalse: [ 0 ]
+]
+
+{ #category : #private }
+NSNiceLinearTicksGenerator >> w: s c: c d: d l: l [
+	^ (w first * s) + (w second * c) + (w third * d) + (w fourth * l)
+]

--- a/src/NumericInterpolator/NSPowScale.class.st
+++ b/src/NumericInterpolator/NSPowScale.class.st
@@ -66,6 +66,12 @@ NSPowScale >> invert: x [
 	^ powb scale: (linear invert: x)
 ]
 
+{ #category : #accessing }
+NSPowScale >> niceTicks: aNumberOfTicks [
+
+	^ self ticks: aNumberOfTicks
+]
+
 { #category : #initialization }
 NSPowScale >> range [
 	^ linear range

--- a/src/NumericInterpolator/NSPowScale.class.st
+++ b/src/NumericInterpolator/NSPowScale.class.st
@@ -3,12 +3,13 @@ I scale using pow function
 "
 Class {
 	#name : #NSPowScale,
-	#superclass : #NSLinearScale,
+	#superclass : #NSScale,
 	#instVars : [
 		'linear',
 		'exponent',
 		'powp',
-		'powb'
+		'powb',
+		'anInteger'
 	],
 	#category : #'NumericInterpolator-Scales'
 }
@@ -79,6 +80,8 @@ NSPowScale >> range [
 
 { #category : #initialization }
 NSPowScale >> range: x [
+
+	range := x.
 	linear range: x
 ]
 

--- a/src/NumericInterpolator/NSPowScale.class.st
+++ b/src/NumericInterpolator/NSPowScale.class.st
@@ -67,12 +67,6 @@ NSPowScale >> invert: x [
 	^ powb scale: (linear invert: x)
 ]
 
-{ #category : #accessing }
-NSPowScale >> niceTicks: aNumberOfTicks [
-
-	^ self ticks: aNumberOfTicks
-]
-
 { #category : #initialization }
 NSPowScale >> range [
 	^ linear range

--- a/src/NumericInterpolator/NSScale.class.st
+++ b/src/NumericInterpolator/NSScale.class.st
@@ -263,7 +263,7 @@ NSScale >> invert: anObject [
 { #category : #accessing }
 NSScale >> niceTicks: aNumberOfTicks [
 
-	
+	^ self ticks: aNumberOfTicks
 ]
 
 { #category : #printing }
@@ -322,6 +322,15 @@ NSScale >> rsValue: obj [
 NSScale >> scale: anObject [
 	"do you have your domain, and your range? ok so use this method in one of my subclasses"
 	self subclassResponsibility
+]
+
+{ #category : #transformation }
+NSScale >> ticks: anInteger [
+
+	| rangeForDividing |
+	rangeForDividing := range first to: range last count: anInteger.
+
+	^ rangeForDividing collect: [ :e | self invert: e ]
 ]
 
 { #category : #accessing }

--- a/src/NumericInterpolator/NSScale.class.st
+++ b/src/NumericInterpolator/NSScale.class.st
@@ -260,6 +260,12 @@ NSScale >> invert: anObject [
 	self subclassResponsibility
 ]
 
+{ #category : #accessing }
+NSScale >> niceTicks: aNumberOfTicks [
+
+	
+]
+
 { #category : #printing }
 NSScale >> printOn: stream [
 	super printOn: stream.

--- a/src/NumericInterpolator/NSScale.class.st
+++ b/src/NumericInterpolator/NSScale.class.st
@@ -308,11 +308,6 @@ Return a gray-red color`
 	range := someValues
 ]
 
-{ #category : #hooks }
-NSScale >> rescale [
-	self subclassResponsibility
-]
-
 { #category : #transformation }
 NSScale >> rsValue: obj [
 	^ self scale: obj
@@ -329,7 +324,6 @@ NSScale >> ticks: anInteger [
 
 	| rangeForDividing |
 	rangeForDividing := range first to: range last count: anInteger.
-
 	^ rangeForDividing collect: [ :e | self invert: e ]
 ]
 

--- a/src/NumericInterpolator/NSSymLogScale.class.st
+++ b/src/NumericInterpolator/NSSymLogScale.class.st
@@ -62,6 +62,12 @@ NSSymLogScale >> invert: x [
 ]
 
 { #category : #accessing }
+NSSymLogScale >> niceTicks: aNumberOfTicks [
+
+	^ self ticks: aNumberOfTicks
+]
+
+{ #category : #accessing }
 NSSymLogScale >> range [
 	^ linear range
 ]

--- a/src/NumericInterpolator/NSSymLogScale.class.st
+++ b/src/NumericInterpolator/NSSymLogScale.class.st
@@ -62,12 +62,6 @@ NSSymLogScale >> invert: x [
 ]
 
 { #category : #accessing }
-NSSymLogScale >> niceTicks: aNumberOfTicks [
-
-	^ self ticks: aNumberOfTicks
-]
-
-{ #category : #accessing }
 NSSymLogScale >> range [
 	^ linear range
 ]

--- a/src/NumericInterpolator/NSSymLogScale.class.st
+++ b/src/NumericInterpolator/NSSymLogScale.class.st
@@ -5,7 +5,7 @@ Inspired from https://github.com/d3/d3-scale/blob/master/src/symlog.js
 "
 Class {
 	#name : #NSSymLogScale,
-	#superclass : #NSLinearScale,
+	#superclass : #NSScale,
 	#instVars : [
 		'constant',
 		'linear'
@@ -74,6 +74,8 @@ NSSymLogScale >> range [
 
 { #category : #accessing }
 NSSymLogScale >> range: x [
+
+	range := x.
 	linear range: x
 ]
 

--- a/src/NumericInterpolator/RSNiceLinearScaleResult.class.st
+++ b/src/NumericInterpolator/RSNiceLinearScaleResult.class.st
@@ -1,0 +1,106 @@
+"
+I am an utility class for RSLabelGenerator.
+
+-=-=-=-=-=-=-=-=-=
+values := #(1 2.3 4.3).
+c := RSChart new.
+d := RSScatterPlot new x: values y: values.
+c addPlot: d.
+c addDecoration: RSHorizontalTick new.
+
+tick := RSVerticalTick new.
+c addDecoration: tick.
+c build.
+
+tick createNiceLabelIn: c 
+-=-=-=-=-=-=-=-=-=
+
+prints the following: ""(Score: 0.75) 1.00	2.00	3.00	4.00	5.00	""
+					
+The min and max represents the range of the ticks
+"
+Class {
+	#name : #RSNiceLinearScaleResult,
+	#superclass : #RSObject,
+	#instVars : [
+		'min',
+		'max',
+		'step',
+		'score'
+	],
+	#category : #'NumericInterpolator-Nice Scaling'
+}
+
+{ #category : #initialization }
+RSNiceLinearScaleResult >> initialize [
+	super initialize.
+	score := 0
+]
+
+{ #category : #accessing }
+RSNiceLinearScaleResult >> max [
+	^ max
+]
+
+{ #category : #accessing }
+RSNiceLinearScaleResult >> max: aNumber [
+	max := aNumber
+]
+
+{ #category : #accessing }
+RSNiceLinearScaleResult >> min [
+	^ min
+]
+
+{ #category : #accessing }
+RSNiceLinearScaleResult >> min: aNumber [
+	min := aNumber
+]
+
+{ #category : #accessing }
+RSNiceLinearScaleResult >> numberOfTicks [
+	^ self ticks / step
+]
+
+{ #category : #printing }
+RSNiceLinearScaleResult >> printOn: aStream [
+	| x |
+	aStream
+		nextPutAll: '(Score: ';
+		nextPutAll: (score printShowingDecimalPlaces: 2);
+		nextPutAll: ') '.
+	x := min.
+	[x <= max ] whileTrue: [
+		aStream nextPutAll: (x printShowingDecimalPlaces: 2).
+		aStream nextPutAll: String tab.
+		x := x + step ]
+]
+
+{ #category : #accessing }
+RSNiceLinearScaleResult >> score [
+	^ score
+]
+
+{ #category : #accessing }
+RSNiceLinearScaleResult >> score: aNumber [
+	score := aNumber
+]
+
+{ #category : #accessing }
+RSNiceLinearScaleResult >> step [
+	^ step
+]
+
+{ #category : #accessing }
+RSNiceLinearScaleResult >> step: aNumber [
+	step := aNumber
+]
+
+{ #category : #accessing }
+RSNiceLinearScaleResult >> ticks [
+	^  min < 0 ifTrue: [
+		 max < 0
+			ifTrue: [ (max - min) abs ]
+			ifFalse: [ max + min abs  ]
+	] ifFalse: [ max - min ]
+]


### PR DESCRIPTION
The classes:
-log
-ln
-sym log
- pow

are not a subclass of linear scale anymore. There was a bug because of that because the method `rescale` of the linear scale uses a `linear` temp variable that is an instance variable in the subclasses. Also problems because there was two ranges